### PR TITLE
Black/Dark Theme: Support theming notificatons

### DIFF
--- a/dark/res/values/colors.xml
+++ b/dark/res/values/colors.xml
@@ -1,8 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Resolver -->
+    <color name="resolver_list_bg">@*android:color/background_material_dark</color>
+
+    <!-- Immersive cling -->
+    <color name="immersive_cling_bg_color">@*android:color/background_material_dark</color>
+    <color name="immersive_cling_text_color">@android:color/white</color>
+    <color name="immersive_cling_button_text_color">@android:color/white</color>
+
+    <!-- App permission tint -->
+    <color name="app_permission_icon_tint">@android:color/white</color>
+
     <!-- Toast text and bg colors -->
     <color name="toast_bg_color">#cc212121</color>
     <color name="toast_text_color">@*android:color/primary_text_default_material_dark</color>
 
+    <!-- Color Constants -->
+    <color name="theme_text1">#FFE8EAF6</color> <!-- text primary -->
+    <color name="theme_text2">#B3E8EAF6</color>  <!-- text secondary -->
+
+    <!-- Notifications -->
+    <color name="notification_legacy_background_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_material_background_dimmed_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_material_background_low_priority_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_divider_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_shade_background_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_guts_bg_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_material_background_color">@*android:color/primary_device_default_dark</color>
+    <color name="notification_default_color">@*android:color/theme_text1</color> <!-- Gray 600 -->
+    <color name="notification_action_list">@*android:color/primary_device_default_dark</color>
+    <color name="notification_action_list_dark">@*android:color/primary_device_default_dark</color>
+    <color name="notification_primary_text_color_light">@*android:color/theme_text1</color>
+    <color name="notification_secondary_text_color_light">@*android:color/theme_text2</color>
+    <color name="notification_progress_background_color">@*android:color/theme_text2</color>
+    <color name="notification_snooze_text">@*android:color/theme_text1</color>
+    <color name="notification_text_color1">@*android:color/theme_text1</color>
 </resources>

--- a/dark/res/values/config.xml
+++ b/dark/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <resources>
+    <bool name="config_useDarkBgNotificationTinting_override">true</bool>
+    <bool name="config_notificationTinting_override">true</bool>
+ </resources>

--- a/primary/black/android/res/values/colors.xml
+++ b/primary/black/android/res/values/colors.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <!-- Toast text and bg colors -->
-    <color name="toast_bg_color">#cc000000</color>
-    <color name="toast_text_color">@*android:color/primary_text_default_material_dark</color>
     <!-- System Backgrounds -->	
     <color name="material_grey_900">@*android:color/black</color>
     <color name="material_grey_850">@*android:color/black</color>
@@ -13,12 +9,40 @@
     <color name="material_blue_grey_800">@*android:color/black</color>
     <color name="material_blue_grey_900">@*android:color/black</color>
     <color name="material_blue_grey_950">@*android:color/black</color>
+
+    <!-- Resolver -->
+    <color name="resolver_list_bg">@*android:color/black</color>
+
     <!-- Immersive cling -->
     <color name="immersive_cling_bg_color">@*android:color/black</color>
     <color name="immersive_cling_text_color">@android:color/white</color>
     <color name="immersive_cling_button_text_color">@android:color/white</color>
 
-    <!-- Resolver -->
-    <color name="resolver_list_bg">@*android:color/black</color>
+    <!-- App permission tint -->
+    <color name="app_permission_icon_tint">@android:color/white</color>
 
+    <!-- Toast text and bg colors -->
+    <color name="toast_bg_color">#cc000000</color>
+    <color name="toast_text_color">@*android:color/primary_text_default_material_dark</color>
+
+    <!-- Color Constants -->
+    <color name="theme_text1">#ffe5e5e5</color> <!-- text primary -->
+    <color name="theme_text2">#b3e5e5e5</color>  <!-- text secondary -->
+
+    <!-- Notifications -->
+    <color name="notification_legacy_background_color">@*android:color/black</color>
+    <color name="notification_material_background_dimmed_color">@*android:color/black</color>
+    <color name="notification_material_background_low_priority_color">@*android:color/black</color>
+    <color name="notification_divider_color">@*android:color/black</color>
+    <color name="notification_shade_background_color">@*android:color/black</color>
+    <color name="notification_guts_bg_color">@*android:color/black</color>
+    <color name="notification_material_background_color">@*android:color/black</color>
+    <color name="notification_default_color">@*android:color/theme_text1</color> <!-- Gray 600 -->
+    <color name="notification_action_list">@*android:color/black</color>
+    <color name="notification_action_list_dark">@*android:color/black</color>
+    <color name="notification_primary_text_color_light">@*android:color/theme_text1</color>
+    <color name="notification_secondary_text_color_light">@*android:color/theme_text2</color>
+    <color name="notification_progress_background_color">@*android:color/theme_text2</color>
+    <color name="notification_snooze_text">@*android:color/theme_text1</color>
+    <color name="notification_text_color1">@*android:color/theme_text1</color>
 </resources>

--- a/primary/black/android/res/values/config.xml
+++ b/primary/black/android/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_useDarkBgNotificationTinting_override">true</bool>
+    <bool name="config_notificationTinting_override">true</bool>
+</resources>


### PR DESCRIPTION
@maxwen
* themes: fix notification overlay config [2/2]
for notification overlays to correctly tint notification texts
we must add a way they can override whatever is in the primary
overlay

@mcdachpappe 
* clean up and reorder xml files
* adapted to work with lineageos/resurrectionremix